### PR TITLE
Fix unsafe `String.replaceAll(regex` call

### DIFF
--- a/saleson-web/src/main/java/saleson/common/module/smarteditor/SmartEditorController.java
+++ b/saleson-web/src/main/java/saleson/common/module/smarteditor/SmartEditorController.java
@@ -245,7 +245,7 @@ public class SmartEditorController {
 		
 		// 컨텐츠에 이미지 변환 
 		for (HashMap<String, String> fileInfo : uploadImages) {
-			ctpContent = ctpContent.replaceAll("./" + fileInfo.get("originalFilename"), "/upload/ctp/" + ctpFilename + "_" + uniqueFolderName + "/" + fileInfo.get("newFilename"));
+			ctpContent = ctpContent.replace("./" + fileInfo.get("originalFilename"), "/upload/ctp/" + ctpFilename + "_" + uniqueFolderName + "/" + fileInfo.get("newFilename"));
 		}
 	
 		// body 안의 내용만 가져온다. <body> ~ </body>


### PR DESCRIPTION
This pull request fixes a potential security vulnerability, where user controlled `ctpContent` and `originalFilename` are used in a `String.replaceAll(String regex, String replacement)` call. Since the attackers control the string and the regex pattern they may cause a ReDoS (denial of service) by regex catastrophic backtracking on the server side.

The fix is to use `String.replace(CharSequence,CharSequence)` rather than `replaceAll`. Despite the name it replaces all occurrences. 